### PR TITLE
docs: streamline README to reduce redundancy in options sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,25 +58,13 @@ func main() {
 }
 ```
 
-### Creating Default Options
-
-If you need to reuse a set of default options across multiple requests, you can create a function that returns multiple options:
+You can also combine multiple options using `option.NewOptions()` to create reusable defaults:
 
 ```go
 func myDefaults() option.Option[*http.Request] {
     return option.NewOptions(
         qst.WithURL("https://breakfast.com/api"),
         qst.WithBearerAuth("c0rNfl@k3s"),
-    )
-}
-
-func main() {
-    response, err := qst.Patch("https://breakfast.com/api",
-        myDefaults(),
-        qst.WithPath("/cereals", cerealID),
-        qst.WithBodyJSON(map[string]interface{}{
-            "name": "Golden Grahams",
-        }),
     )
 }
 ```


### PR DESCRIPTION
Remove redundant "Creating Default Options" section that overlapped with basic usage examples and comprehensive options reference. Preserve the option.NewOptions() pattern with a concise example in the usage section.

Fixes #16

Generated with [Claude Code](https://claude.ai/code)